### PR TITLE
## [3.7.0] — 2024-06-07

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.7.0] — 2024-06-07
+
+### Added
+
+- Required Theme Components Autodetect: We are now reading a theme's section files to scan for required components #
+
+### Changed
+
+- install cmd: We now use the new required theme components autodetect feature instead of defaulting to all components
+
 ## [3.6.1] — 2024-06-04
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - install cmd: We now use the new required theme components autodetect feature instead of defaulting to all components
 - Dependencies: Minor updates
 
+### Fixed
+
+- install cmd: Import Map caused Errors when installing a single component with no Js Files
+
 ## [3.6.1] — 2024-06-04
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - install cmd: We now use the new required theme components autodetect feature instead of defaulting to all components
+- Dependencies: Minor updates
 
 ## [3.6.1] — 2024-06-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - install cmd: We now use the new required theme components autodetect feature instead of defaulting to all components
 - Dependencies: Minor updates
+- ImportMap: importmap.json can now handle array values. The values can include glob patterns or ignore patterns
+  starting with "!"
+- ImportMap: Filtering removed — Whatever globs are in the Import Map is what gets output
 
 ### Fixed
 
@@ -62,6 +65,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The build process does not write to disk anymore, only install does
 - Dependencies: Minor updates
 -
+
 ### Removed
 
 - Automated Dependabot updates for Node.js packages were removed. We never use it.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Required Theme Components Autodetect: We are now reading a theme's section files to scan for required components #
+- Required Theme Components Autodetect: We are now reading a theme's section files to scan for required components #403
 
 ### Changed
 
-- install cmd: We now use the new required theme components autodetect feature instead of defaulting to all components
+- install cmd: We now use the new required theme components autodetect feature instead of defaulting to all components #403
 - Dependencies: Minor updates
 - ImportMap: importmap.json can now handle array values. The values can include glob patterns or ignore patterns
   starting with "!"

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ DESCRIPTION
   Theme Component Plugin - By Archetype Themes
 ```
 
-_See code: [src/commands/theme/component/index.js](https://github.com/archetype-themes/plugin-theme-component/blob/v3.6.1/src/commands/theme/component/index.js)_
+_See code: [src/commands/theme/component/index.js](https://github.com/archetype-themes/plugin-theme-component/blob/v3.7.0/src/commands/theme/component/index.js)_
 
 ## `shopify theme component dev [COMPONENTS]`
 
@@ -111,7 +111,7 @@ FLAG DESCRIPTIONS
     options for that command in your toml file.
 ```
 
-_See code: [src/commands/theme/component/dev.js](https://github.com/archetype-themes/plugin-theme-component/blob/v3.6.1/src/commands/theme/component/dev.js)_
+_See code: [src/commands/theme/component/dev.js](https://github.com/archetype-themes/plugin-theme-component/blob/v3.7.0/src/commands/theme/component/dev.js)_
 
 ## `shopify theme component generate COMPONENTS`
 
@@ -132,7 +132,7 @@ DESCRIPTION
   Generate canvas files for new components
 ```
 
-_See code: [src/commands/theme/component/generate.js](https://github.com/archetype-themes/plugin-theme-component/blob/v3.6.1/src/commands/theme/component/generate.js)_
+_See code: [src/commands/theme/component/generate.js](https://github.com/archetype-themes/plugin-theme-component/blob/v3.7.0/src/commands/theme/component/generate.js)_
 
 ## `shopify theme component install [COMPONENTS]`
 
@@ -171,7 +171,7 @@ FLAG DESCRIPTIONS
     publicly shared locales database.
 ```
 
-_See code: [src/commands/theme/component/install.js](https://github.com/archetype-themes/plugin-theme-component/blob/v3.6.1/src/commands/theme/component/install.js)_
+_See code: [src/commands/theme/component/install.js](https://github.com/archetype-themes/plugin-theme-component/blob/v3.7.0/src/commands/theme/component/install.js)_
 <!-- commandsstop -->
 
 ## Contributing

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@inquirer/prompts": "^5.0.5",
         "@oclif/core": "3.26.5",
         "@shopify/browserslist-config": "^3.0.0",
-        "@shopify/cli-kit": "3.61.0",
+        "@shopify/cli-kit": "3.61.1",
         "@types/node": "^18.19.34",
         "chokidar": "^3.6.0",
         "deepmerge": "^4.3.1",
@@ -45,7 +45,7 @@
         "eslint-plugin-promise": "^6.2.0",
         "mocha": "^10.4.0",
         "oclif": "^4.13.0",
-        "prettier": "^3.3.0",
+        "prettier": "^3.3.1",
         "shx": "^0.3.4"
       },
       "engines": {
@@ -3842,9 +3842,9 @@
       "license": "MIT"
     },
     "node_modules/@shopify/cli-kit": {
-      "version": "3.61.0",
-      "resolved": "https://registry.npmjs.org/@shopify/cli-kit/-/cli-kit-3.61.0.tgz",
-      "integrity": "sha512-yEnMpTr6ODqMEWdta2SdMGThwnAownI8YeT/I4V5BTmT7+2sRgCfjsBK96I+mESWbkUbvWA2PjVJzKyTtjb0Dg==",
+      "version": "3.61.1",
+      "resolved": "https://registry.npmjs.org/@shopify/cli-kit/-/cli-kit-3.61.1.tgz",
+      "integrity": "sha512-mXzlMb5JI6dUaW6xNsLuCWcrSmOTO7zgbcFWbF5lN8+J83EQIEwdYpG1r4EOtTqkVr1Bwcb9zowDMLx5tH7N8w==",
       "license": "MIT",
       "os": [
         "darwin",
@@ -3910,7 +3910,7 @@
         "zod": "3.22.3"
       },
       "engines": {
-        "node": ">=18.12.0"
+        "node": "^18.20.0 || >=20.10.0"
       }
     },
     "node_modules/@shopify/cli-kit/node_modules/ansi-escapes": {
@@ -12773,9 +12773,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.3.0.tgz",
-      "integrity": "sha512-J9odKxERhCQ10OC2yb93583f6UnYutOeiV5i0zEDS7UGTdUt0u+y8erxl3lBKvwo/JHyyoEdXjwp4dke9oyZ/g==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.3.1.tgz",
+      "integrity": "sha512-7CAwy5dRsxs8PHXT3twixW9/OEll8MLE0VRPCJyl7CkS6VHGPSlsVaWTiASPTyGyYRyApxlaWTzwUxVNrhcwDg==",
       "dev": true,
       "license": "MIT",
       "bin": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "plugin-theme-component",
-  "version": "3.6.1",
+  "version": "3.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "plugin-theme-component",
-      "version": "3.6.1",
+      "version": "3.7.0",
       "license": "MIT",
       "dependencies": {
         "@iarna/toml": "2.2.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "plugin-theme-component",
-  "version": "3.6.1",
+  "version": "3.7.0",
   "type": "module",
   "description": "Archetype Theme's Shopify CLI theme component plugin",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "@inquirer/prompts": "^5.0.5",
     "@oclif/core": "3.26.5",
     "@shopify/browserslist-config": "^3.0.0",
-    "@shopify/cli-kit": "3.61.0",
+    "@shopify/cli-kit": "3.61.1",
     "@types/node": "^18.19.34",
     "chokidar": "^3.6.0",
     "deepmerge": "^4.3.1",
@@ -64,7 +64,7 @@
     "eslint-plugin-promise": "^6.2.0",
     "mocha": "^10.4.0",
     "oclif": "^4.13.0",
-    "prettier": "^3.3.0",
+    "prettier": "^3.3.1",
     "shx": "^0.3.4"
   },
   "engines": {

--- a/src/builders/collectionBuilder.js
+++ b/src/builders/collectionBuilder.js
@@ -8,7 +8,7 @@ import Timer from '../models/Timer.js'
 import Session from '../models/static/Session.js'
 import LocalesProcessor from '../processors/LocalesProcessor.js'
 import PostCSSProcessor from '../processors/PostCSSProcessor.js'
-import { getFolderFilesRecursively } from '../utils/fileUtils.js'
+import { getFiles } from '../utils/fileUtils.js'
 import { error, fatal, logChildItem, logSpacer, logTitleItem, warn } from '../utils/logger.js'
 import { ChangeType } from '../utils/Watcher.js'
 import ImportMapProcessor from '../processors/ImportMapProcessor.js'
@@ -141,7 +141,7 @@ async function buildLocales(liquidCodeExcerpts) {
   try {
     logChildItem('Starting The Locales Processor', 1)
     const timer = new Timer()
-    const localeFiles = await getFolderFilesRecursively(join(Session.localesPath, LOCALES_FOLDER_NAME))
+    const localeFiles = await getFiles(join(Session.localesPath, LOCALES_FOLDER_NAME), true)
     const locales = await LocalesProcessor.build(liquidCodeExcerpts, localeFiles)
     logChildItem(`Locales Processor Done (${timer.now()} seconds)`, 1)
     return locales

--- a/src/commands/theme/component/dev.js
+++ b/src/commands/theme/component/dev.js
@@ -121,7 +121,7 @@ export default class Dev extends BaseCommand {
 
     await Dev.setSessionValues(argv, flags, metadata, tomlConfig)
 
-    const collection = await Dev.exploreComponent(Session.themePath, Session.components)
+    const collection = await Dev.exploreComponent(Session.themePath, Session.componentNames)
 
     if (Session.firstRun && Session.setupFiles) {
       const installFolder = join(collection.rootFolder, DEV_FOLDER_NAME)
@@ -144,7 +144,7 @@ export default class Dev extends BaseCommand {
         collection.rootFolder,
         getIgnorePatterns(collection.rootFolder),
         Session.themePath,
-        Session.components
+        Session.componentNames
       )
     )
 
@@ -169,13 +169,13 @@ export default class Dev extends BaseCommand {
       )
       // Ignore all storefront locale files
       ignorePatterns.push(/(^|[/\\])locales(?!.*schema\.json$).*\.json$/)
-      promises.push(Dev.watchTheme(Session.themePath, ignorePatterns, collection.rootFolder, Session.components))
+      promises.push(Dev.watchTheme(Session.themePath, ignorePatterns, collection.rootFolder, Session.componentNames))
       logInitLines.push(`${collection.name}: Watching theme folder for changes`)
     }
 
     // Watch Local Locales
     if (!isGitHubUrl(Session.localesPath)) {
-      promises.push(Dev.watchLocales(Session.localesPath, Session.themePath, Session.components))
+      promises.push(Dev.watchLocales(Session.localesPath, Session.themePath, Session.componentNames))
       logInitLines.push(`${collection.name}: Watching locales folder for changes`)
     }
 
@@ -353,7 +353,7 @@ export default class Dev extends BaseCommand {
    */
   static async setSessionValues(argv, flags, metadata, tomlConfig) {
     Session.callerType = COLLECTION_TYPE_NAME
-    Session.components = getValuesFromArgvOrToml(COMPONENT_ARG_NAME, argv, tomlConfig)
+    Session.componentNames = getValuesFromArgvOrToml(COMPONENT_ARG_NAME, argv, tomlConfig)
     Session.localesPath = await getPathFromFlagOrTomlValue(LOCALES_FLAG_NAME, flags, metadata, tomlConfig)
     Session.syncMode = getValueFromFlagOrToml(THEME_SYNC_FLAG_NAME, flags, metadata, tomlConfig)
     Session.watchMode = getValueFromFlagOrToml(WATCH_FLAG_NAME, flags, metadata, tomlConfig)

--- a/src/commands/theme/component/dev.js
+++ b/src/commands/theme/component/dev.js
@@ -41,7 +41,7 @@ import { rm } from 'node:fs/promises'
 import { exists, saveFile } from '../../../utils/fileUtils.js'
 import { getCLIRootFolderName } from '../../../utils/nodeUtils.js'
 import Timer from '../../../models/Timer.js'
-import { displayComponentTree } from '../../../utils/collectionUtils.js'
+import { displayCollectionTree } from '../../../utils/treeUtils.js'
 import { buildCollection } from '../../../builders/collectionBuilder.js'
 
 /** @type {string} **/
@@ -222,7 +222,7 @@ export default class Dev extends BaseCommand {
     // Build & Deploy Collection
     let collection = await this.getCollectionFromCwd(componentNames)
     if (Session.firstRun) {
-      displayComponentTree(collection)
+      displayCollectionTree(collection)
     }
     collection = await buildCollection(collection)
 

--- a/src/commands/theme/component/generate.js
+++ b/src/commands/theme/component/generate.js
@@ -34,7 +34,7 @@ export default class Generate extends BaseCommand {
 
     await Generate.setSessionValues(argv, tomlConfig)
 
-    for (const componentName of Session.components) {
+    for (const componentName of Session.componentNames) {
       logTitleItem(`Generating "${componentName}" ${COMPONENT_TYPE_NAME}`)
 
       const componentPath = join(COMPONENTS_FOLDER, componentName)
@@ -98,6 +98,6 @@ export default class Generate extends BaseCommand {
 
   static async setSessionValues(argv, tomlConfig) {
     Session.callerType = COLLECTION_TYPE_NAME
-    Session.components = getValuesFromArgvOrToml(COMPONENT_ARG_NAME, argv, tomlConfig)
+    Session.componentNames = getValuesFromArgvOrToml(COMPONENT_ARG_NAME, argv, tomlConfig)
   }
 }

--- a/src/commands/theme/component/generate.js
+++ b/src/commands/theme/component/generate.js
@@ -9,7 +9,7 @@ import { BaseCommand, COMPONENT_ARG_NAME } from '../../../config/baseCommand.js'
 import { COLLECTION_TYPE_NAME, COMPONENT_TYPE_NAME, COMPONENTS_FOLDER } from '../../../config/constants.js'
 import FileAccessError from '../../../errors/FileAccessError.js'
 import Session from '../../../models/static/Session.js'
-import { copyFolder, getFolderFilesRecursively } from '../../../utils/fileUtils.js'
+import { copyFolder, getFiles } from '../../../utils/fileUtils.js'
 import { getCLIRootFolderName, getPackageManifest, getPackageName, getPackageScope } from '../../../utils/nodeUtils.js'
 import { getValuesFromArgvOrToml } from '../../../utils/sessionUtils.js'
 import { logChildItem, logSeparator, logTitleItem } from '../../../utils/logger.js'
@@ -87,7 +87,7 @@ export default class Generate extends BaseCommand {
 
       logChildItem('Done')
       logTitleItem('The following files were created:')
-      const files = await getFolderFilesRecursively(componentPath)
+      const files = await getFiles(componentPath, true)
       files.forEach((file) => logChildItem(relative(componentPath, file)))
 
       logTitleItem('Your new component is available at')

--- a/src/commands/theme/component/install.js
+++ b/src/commands/theme/component/install.js
@@ -1,21 +1,22 @@
 // External Dependencies
+import { cwd } from 'node:process'
 import { Args, Flags } from '@oclif/core'
 
 // Internal Dependencies
+import { buildCollection } from '../../../builders/collectionBuilder.js'
 import { BaseCommand, COMPONENT_ARG_NAME, LOCALES_FLAG_NAME } from '../../../config/baseCommand.js'
 import { THEME_TYPE_NAME } from '../../../config/constants.js'
-import { getPathFromFlagOrTomlValue, getValuesFromArgvOrToml } from '../../../utils/sessionUtils.js'
-import { getCurrentTime } from '../../../utils/dateUtils.js'
 import { collectionFactory } from '../../../factory/collectionFactory.js'
+import { themeFactory } from '../../../factory/themeFactory.js'
 import { installCollection } from '../../../installers/collectionInstaller.js'
 import Session from '../../../models/static/Session.js'
-import { themeFactory } from '../../../factory/themeFactory.js'
 import Timer from '../../../models/Timer.js'
-import { isGitHubUrl } from '../../../utils/gitUtils.js'
+import { getCurrentTime } from '../../../utils/dateUtils.js'
 import { install } from '../../../utils/externalComponents.js'
+import { isGitHubUrl } from '../../../utils/gitUtils.js'
 import { info, logChildItem } from '../../../utils/logger.js'
-import { cwd } from 'node:process'
-import { buildCollection } from '../../../builders/collectionBuilder.js'
+import { getPathFromFlagOrTomlValue, getValuesFromArgvOrToml } from '../../../utils/sessionUtils.js'
+import { displayCollectionTree, displayThemeTree, setComponentHierarchy } from '../../../utils/treeUtils.js'
 
 const COMPONENTS_FLAG_NAME = 'components-path'
 export default class Install extends BaseCommand {
@@ -78,8 +79,17 @@ export default class Install extends BaseCommand {
     // Create The Theme
     const theme = await themeFactory(cwd())
 
+    const componentNames = Session.componentNames?.length ? Session.componentNames : [...theme.snippetNames]
     // Create The Collection
-    const collection = await collectionFactory(Session.componentsPath, Session.components)
+    const collection = await collectionFactory(Session.componentsPath, componentNames)
+
+    // If no component names are provided, use theme sections' render names
+    if (!Session.componentNames?.length) {
+      await setComponentHierarchy(theme.sections, collection.allComponents)
+      displayThemeTree(theme)
+    } else {
+      displayCollectionTree(collection)
+    }
 
     await Install.installOne(theme, collection)
   }

--- a/src/commands/theme/component/install.js
+++ b/src/commands/theme/component/install.js
@@ -76,7 +76,7 @@ export default class Install extends BaseCommand {
     }
 
     // Create The Theme
-    const theme = themeFactory(cwd())
+    const theme = await themeFactory(cwd())
 
     // Create The Collection
     const collection = await collectionFactory(Session.componentsPath, Session.components)

--- a/src/commands/theme/component/install.js
+++ b/src/commands/theme/component/install.js
@@ -108,7 +108,7 @@ export default class Install extends BaseCommand {
 
   static async setSessionValues(argv, flags, metadata, tomlConfig) {
     Session.callerType = THEME_TYPE_NAME
-    Session.components = getValuesFromArgvOrToml(COMPONENT_ARG_NAME, argv, tomlConfig)
+    Session.componentNames = getValuesFromArgvOrToml(COMPONENT_ARG_NAME, argv, tomlConfig)
     Session.componentsPath = await getPathFromFlagOrTomlValue(COMPONENTS_FLAG_NAME, flags, metadata, tomlConfig)
     Session.localesPath = await getPathFromFlagOrTomlValue(LOCALES_FLAG_NAME, flags, metadata, tomlConfig)
   }

--- a/src/factory/collectionFactory.js
+++ b/src/factory/collectionFactory.js
@@ -3,7 +3,7 @@ import { basename, join, sep } from 'node:path'
 
 // Internal Dependencies
 import Collection from '../models/Collection.js'
-import { getComponentHierarchyNames } from '../utils/collectionUtils.js'
+import { getComponentHierarchyNames } from '../utils/treeUtils.js'
 import { fatal, logChildItem, logTitleItem } from '../utils/logger.js'
 import Timer from '../models/Timer.js'
 import { plural } from '../utils/textUtils.js'

--- a/src/factory/collectionFactory.js
+++ b/src/factory/collectionFactory.js
@@ -60,9 +60,7 @@ export async function collectionFactory(path, componentNames) {
     collection.components = filterComponents(collection.components, collection.componentNames)
     collection.snippets = filterSnippets(collection.snippets, collection.componentNames)
 
-    logChildItem(
-      `Packaging the following ${collection.componentNames.size} component${plural(collection.componentNames)}: ${[...collection.componentNames].join(', ')}`
-    )
+    logChildItem(`Packaging ${collection.componentNames.size} component${plural(collection.componentNames)}`)
   }
 
   // Throw an Error when No Components are found

--- a/src/factory/collectionFactory.js
+++ b/src/factory/collectionFactory.js
@@ -3,7 +3,7 @@ import { basename, join, sep } from 'node:path'
 
 // Internal Dependencies
 import Collection from '../models/Collection.js'
-import { getComponentNamesHierarchy } from '../utils/collectionUtils.js'
+import { getComponentHierarchyNames } from '../utils/collectionUtils.js'
 import { fatal, logChildItem, logTitleItem } from '../utils/logger.js'
 import Timer from '../models/Timer.js'
 import { plural } from '../utils/textUtils.js'
@@ -56,7 +56,7 @@ export async function collectionFactory(path, componentNames) {
   )
 
   if (componentNames?.length) {
-    collection.componentNames = getComponentNamesHierarchy(collection.allComponents, componentNames)
+    collection.componentNames = getComponentHierarchyNames(collection.allComponents, componentNames)
     collection.components = filterComponents(collection.components, collection.componentNames)
     collection.snippets = filterSnippets(collection.snippets, collection.componentNames)
 

--- a/src/factory/collectionFactory.js
+++ b/src/factory/collectionFactory.js
@@ -61,7 +61,7 @@ export async function collectionFactory(path, componentNames) {
     collection.snippets = filterSnippets(collection.snippets, collection.componentNames)
 
     logChildItem(
-      `Packaging the following component${plural(collection.componentNames)}: ${[...collection.componentNames].join(', ')}`
+      `Packaging the following ${collection.componentNames.size} component${plural(collection.componentNames)}: ${[...collection.componentNames].join(', ')}`
     )
   }
 

--- a/src/factory/collectionFactory.js
+++ b/src/factory/collectionFactory.js
@@ -3,8 +3,8 @@ import { basename, join, sep } from 'node:path'
 
 // Internal Dependencies
 import Collection from '../models/Collection.js'
-import { getComponentHierarchyNames } from '../utils/treeUtils.js'
-import { fatal, logChildItem, logTitleItem } from '../utils/logger.js'
+import { getComponentHierarchyNames, setComponentHierarchy } from '../utils/treeUtils.js'
+import { logChildItem, logTitleItem } from '../utils/logger.js'
 import Timer from '../models/Timer.js'
 import { plural } from '../utils/textUtils.js'
 import { exists, getFolders } from '../utils/fileUtils.js'
@@ -147,24 +147,4 @@ function filterComponents(components, componentNames) {
  */
 function filterSnippets(snippets, componentNames) {
   return snippets.filter((snippet) => componentNames.has(snippet.name))
-}
-
-/**
- * Attach Child Components
- * @param {Component[]|Snippet[]} topComponents
- * @param {(Component|Snippet)[]} availableComponents
- */
-async function setComponentHierarchy(topComponents, availableComponents) {
-  for (const topComponent of topComponents) {
-    if (!topComponent.snippets?.length && topComponent.snippetNames?.length) {
-      for (const snippetName of topComponent.snippetNames) {
-        const snippet = availableComponents.find((component) => component.name === snippetName)
-        if (snippet !== undefined) {
-          topComponent.snippets.push(snippet)
-        } else {
-          fatal(`Unable to find component "${snippetName}" requested from a render tag in "${topComponent.name}".`)
-        }
-      }
-    }
-  }
 }

--- a/src/factory/collectionFactory.js
+++ b/src/factory/collectionFactory.js
@@ -3,7 +3,7 @@ import { basename, join, sep } from 'node:path'
 
 // Internal Dependencies
 import Collection from '../models/Collection.js'
-import { validateComponentNames } from '../utils/collectionUtils.js'
+import { getComponentNamesHierarchy } from '../utils/collectionUtils.js'
 import { fatal, logChildItem, logTitleItem } from '../utils/logger.js'
 import Timer from '../models/Timer.js'
 import { plural } from '../utils/textUtils.js'
@@ -56,8 +56,7 @@ export async function collectionFactory(path, componentNames) {
   )
 
   if (componentNames?.length) {
-    collection.componentNames = validateComponentNames(collection.allComponents, componentNames)
-
+    collection.componentNames = getComponentNamesHierarchy(collection.allComponents, componentNames)
     collection.components = filterComponents(collection.components, collection.componentNames)
     collection.snippets = filterSnippets(collection.snippets, collection.componentNames)
 

--- a/src/factory/componentFilesFactory.js
+++ b/src/factory/componentFilesFactory.js
@@ -2,12 +2,7 @@
 import { dirname, join, sep } from 'node:path'
 
 // Internal Dependencies
-import {
-  convertToComponentRelativePath,
-  getFileType,
-  getFolderFilesRecursively,
-  isReadable
-} from '../utils/fileUtils.js'
+import { convertToComponentRelativePath, getFileType, getFiles, isReadable } from '../utils/fileUtils.js'
 import { ASSETS_FOLDER_NAME, FileTypes, SETUP_FOLDER_NAME } from '../config/constants.js'
 import FileAccessError from '../errors/FileAccessError.js'
 import FileMissingError from '../errors/FileMissingError.js'
@@ -25,7 +20,7 @@ export async function componentFilesFactory(componentName, folder) {
   // Validation: make sure the folder is readable.
   await validateFolderAccess(folder, componentName)
 
-  const files = await getFolderFilesRecursively(folder)
+  const files = await getFiles(folder, true)
 
   const componentFiles = new ComponentFiles()
   // Sort Component files

--- a/src/factory/sectionFactory.js
+++ b/src/factory/sectionFactory.js
@@ -9,7 +9,6 @@ export async function sectionFactory(sectionFile) {
   section.file = sectionFile
   section.liquidCode = await getFileContents(section.file)
   section.snippetNames = getSnippetNames(section.liquidCode)
-  console.log(section.name)
-  console.log(section.snippetNames)
+
   return section
 }

--- a/src/factory/sectionFactory.js
+++ b/src/factory/sectionFactory.js
@@ -1,0 +1,15 @@
+import { Section } from '../models/Section.js'
+import { basename } from 'node:path'
+import { getFileContents } from '../utils/fileUtils.js'
+import { getSnippetNames } from '../utils/liquidUtils.js'
+
+export async function sectionFactory(sectionFile) {
+  const section = new Section()
+  section.name = basename(sectionFile, '.liquid')
+  section.file = sectionFile
+  section.liquidCode = await getFileContents(section.file)
+  section.snippetNames = getSnippetNames(section.liquidCode)
+  console.log(section.name)
+  console.log(section.snippetNames)
+  return section
+}

--- a/src/factory/themeFactory.js
+++ b/src/factory/themeFactory.js
@@ -10,13 +10,15 @@ import {
   SNIPPETS_FOLDER_NAME
 } from '../config/constants.js'
 import Theme from '../models/Theme.js'
+import { sectionFactory } from './sectionFactory.js'
+import { getFiles } from '../utils/fileUtils.js'
 
 /**
  * Theme Factory
  * @param {string} themePath
  * @return {Theme}
  */
-export function themeFactory(themePath) {
+export async function themeFactory(themePath) {
   const theme = new Theme()
 
   theme.name = basename(themePath)
@@ -26,6 +28,13 @@ export function themeFactory(themePath) {
   theme.localesFolder = join(theme.rootFolder, LOCALES_FOLDER_NAME)
   theme.sectionsFolder = join(theme.rootFolder, SECTIONS_FOLDER_NAME)
   theme.snippetsFolder = join(theme.rootFolder, SNIPPETS_FOLDER_NAME)
+
+  const sectionFiles = await getFiles(theme.sectionsFolder)
+
+  const sectionPromises = sectionFiles.map((sectionFile) => sectionFactory(sectionFile))
+  theme.sections = await Promise.all(sectionPromises)
+
+  theme.snippetNames = new Set(theme.sections.flatMap((section) => section.snippetNames))
 
   return theme
 }

--- a/src/factory/themeFactory.js
+++ b/src/factory/themeFactory.js
@@ -11,7 +11,7 @@ import {
 } from '../config/constants.js'
 import Theme from '../models/Theme.js'
 import { sectionFactory } from './sectionFactory.js'
-import { getFiles } from '../utils/fileUtils.js'
+import { exists, getFiles } from '../utils/fileUtils.js'
 
 /**
  * Theme Factory
@@ -29,12 +29,12 @@ export async function themeFactory(themePath) {
   theme.sectionsFolder = join(theme.rootFolder, SECTIONS_FOLDER_NAME)
   theme.snippetsFolder = join(theme.rootFolder, SNIPPETS_FOLDER_NAME)
 
-  const sectionFiles = await getFiles(theme.sectionsFolder)
-
-  const sectionPromises = sectionFiles.map((sectionFile) => sectionFactory(sectionFile))
-  theme.sections = await Promise.all(sectionPromises)
-
-  theme.snippetNames = new Set(theme.sections.flatMap((section) => section.snippetNames))
+  if (await exists(theme.sectionsFolder)) {
+    const sectionFiles = await getFiles(theme.sectionsFolder)
+    const sectionPromises = sectionFiles.map((sectionFile) => sectionFactory(sectionFile))
+    theme.sections = await Promise.all(sectionPromises)
+    theme.snippetNames = new Set(theme.sections.flatMap((section) => section.snippetNames))
+  }
 
   return theme
 }

--- a/src/installers/collectionInstaller.js
+++ b/src/installers/collectionInstaller.js
@@ -178,10 +178,10 @@ async function installImportMapFiles(buildEntries, assetsFolder, copyrightText, 
  */
 async function installJavascriptFiles(jsFiles, importMap, assetsFolder, snippetsFolder, copyrightText, exclusions) {
   const fileOperations = []
-  if (importMap.entries?.size) {
+  if (importMap?.entries.size) {
     fileOperations.push(installImportMapFiles(importMap.entries, assetsFolder, copyrightText, exclusions))
   }
-  if (importMap.tags) {
+  if (importMap?.tags) {
     const importMapSnippet = join(snippetsFolder, IMPORT_MAP_SNIPPET_FILENAME)
     if (!exclusions?.includes(importMapSnippet)) {
       fileOperations.push(saveFile(importMapSnippet, importMap.tags))

--- a/src/models/Section.js
+++ b/src/models/Section.js
@@ -1,0 +1,16 @@
+export class Section {
+  /** @type {string} **/
+  name
+
+  /** @type {string} **/
+  file
+
+  /** @type {string} **/
+  liquidCode
+
+  /** @type {string[]} **/
+  snippetNames
+
+  /** @type {Snippet[]} **/
+  snippets = []
+}

--- a/src/models/Snippet.js
+++ b/src/models/Snippet.js
@@ -1,5 +1,28 @@
-import Component from './Component.js'
+class Snippet {
+  /** @type {string} **/
+  name
 
-class Snippet extends Component {}
+  /** @type {string} **/
+  file
+
+  /** @type {ComponentBuild} **/
+  build
+
+  /** @type {string} **/
+  liquidCode
+
+  /** @type {Object} **/
+  locales = {}
+
+  /** @type {string[]} **/
+  snippetNames
+
+  /** @type {Snippet[]} **/
+  snippets = []
+
+  isSvg() {
+    return !!(this.name.startsWith('icon-') || this.name.endsWith('-svg') || this.name.endsWith('.svg'))
+  }
+}
 
 export default Snippet

--- a/src/models/SnippetBuild.js
+++ b/src/models/SnippetBuild.js
@@ -1,0 +1,6 @@
+class SnippetBuild {
+  /** @type {string} **/
+  liquidCode
+}
+
+export default SnippetBuild

--- a/src/models/Theme.js
+++ b/src/models/Theme.js
@@ -22,6 +22,9 @@ class Theme {
 
   /** @type {string} **/
   snippetsFolder
+
+  /** @type {Set<string>} **/
+  snippetNames
 }
 
 export default Theme

--- a/src/models/Theme.js
+++ b/src/models/Theme.js
@@ -14,6 +14,9 @@ class Theme {
   /** @type {string} **/
   rootFolder
 
+  /** @type {Section[]} **/
+  sections
+
   /** @type {string} **/
   sectionsFolder
 

--- a/src/models/static/Session.js
+++ b/src/models/static/Session.js
@@ -14,7 +14,7 @@ class Session {
   static collections
 
   /** @type {string[]} Target Component Name **/
-  static components
+  static componentNames
 
   /** @type {string} Path to external components **/
   static componentsPath

--- a/src/utils/collectionUtils.js
+++ b/src/utils/collectionUtils.js
@@ -8,7 +8,7 @@ import { info, logSpacer, logTitleItem } from './logger.js'
  * @param {string[]} componentNames
  * @returns {Set<string>}
  */
-export function validateComponentNames(components, componentNames) {
+export function getComponentNamesHierarchy(components, componentNames) {
   let componentsNameTree = new Set(componentNames)
 
   componentNames.forEach((componentName) => {
@@ -20,7 +20,7 @@ export function validateComponentNames(components, componentNames) {
     }
 
     // Recursive call applied to snippet names
-    const componentNameTree = validateComponentNames(components, component.snippetNames)
+    const componentNameTree = getComponentNamesHierarchy(components, component.snippetNames)
     // Merge data with the global Set
     componentsNameTree = new Set([...componentsNameTree, ...componentNameTree])
   })

--- a/src/utils/collectionUtils.js
+++ b/src/utils/collectionUtils.js
@@ -8,8 +8,8 @@ import { info, logSpacer, logTitleItem } from './logger.js'
  * @param {string[]} componentNames
  * @returns {Set<string>}
  */
-export function getComponentNamesHierarchy(components, componentNames) {
-  let componentsNameTree = new Set(componentNames)
+export function getComponentHierarchyNames(components, componentNames) {
+  let componentHierarchyNames = new Set(componentNames)
 
   componentNames.forEach((componentName) => {
     // Find its matching component object
@@ -20,12 +20,12 @@ export function getComponentNamesHierarchy(components, componentNames) {
     }
 
     // Recursive call applied to snippet names
-    const componentNameTree = getComponentNamesHierarchy(components, component.snippetNames)
+    const childComponentHierarchyNames = getComponentHierarchyNames(components, component.snippetNames)
     // Merge data with the global Set
-    componentsNameTree = new Set([...componentsNameTree, ...componentNameTree])
+    componentHierarchyNames = new Set([...componentHierarchyNames, ...childComponentHierarchyNames])
   })
 
-  return componentsNameTree
+  return componentHierarchyNames
 }
 
 export function displayComponentTree(collection) {

--- a/src/utils/fileUtils.js
+++ b/src/utils/fileUtils.js
@@ -1,6 +1,6 @@
 // External Dependencies
 import { access, constants, copyFile, cp, mkdir, readdir, readFile, rm, writeFile } from 'node:fs/promises'
-import { basename, dirname, extname, join, resolve, sep } from 'node:path'
+import { dirname, extname, join, resolve, sep } from 'node:path'
 import { cwd } from 'node:process'
 
 // Internal Dependencies
@@ -43,36 +43,6 @@ export async function copyFileAndCreatePath(file, targetFolder) {
   }
 
   return copyFile(file, targetFolder)
-}
-
-/**
- * Copy All Files to a Specified Folder
- * @param {string[]} files
- * @param {string} destinationFolder
- * @return {Promise<Awaited<void>[]>}
- */
-export async function copyFilesToFolder(files, destinationFolder) {
-  // Filter the files that need to be copied
-  const filesToCopy = []
-  for (const source of files) {
-    const destination = join(destinationFolder, basename(source))
-    if (await isReadable(destination)) {
-      const destinationContents = await getFileContents(destination)
-      const fileContents = await getFileContents(source)
-      if (destinationContents !== fileContents) {
-        filesToCopy.push({ source, destination })
-      }
-    } else {
-      filesToCopy.push({ source, destination })
-    }
-  }
-
-  // Queue the copy operations
-  const filesCopyPromises = filesToCopy.map(({ source, destination }) => {
-    return cp(source, destination, { preserveTimestamps: true })
-  })
-
-  return Promise.all(filesCopyPromises)
 }
 
 /**

--- a/src/utils/fileUtils.js
+++ b/src/utils/fileUtils.js
@@ -148,18 +148,19 @@ export async function getFileContents(file) {
 
 /**
  * Get directory file listing recursively
- * @param folder
+ * @param {string} folder
+ * @param {boolean} [recursive=false]
  * @returns {Promise<string[]>}
  * @link https://stackoverflow.com/questions/5827612/node-js-fs-readdir-recursive-directory-search
  */
-export async function getFolderFilesRecursively(folder) {
+export async function getFiles(folder, recursive = false) {
   const entries = await readdir(folder, { withFileTypes: true })
   const files = []
   for (const entry of entries) {
     const absolutePath = join(folder, entry.name)
     if (entry.isDirectory()) {
-      if (!EXCLUDED_FOLDERS.includes(entry.name)) {
-        files.push(...(await getFolderFilesRecursively(absolutePath)))
+      if (recursive && !EXCLUDED_FOLDERS.includes(entry.name)) {
+        files.push(...(await getFiles(absolutePath, recursive)))
       }
     } else {
       files.push(absolutePath)

--- a/src/utils/textUtils.js
+++ b/src/utils/textUtils.js
@@ -1,8 +1,29 @@
-export function plural(array) {
-  const length = array.length
+import InternalError from '../errors/InternalError.js'
+
+/**
+ * Return plural 's' based on the collection length
+ * @param {Array|Set} collection
+ * @returns {string}
+ */
+export function plural(collection) {
+  let length
+
+  if (Array.isArray(collection)) {
+    length = collection.length
+  } else if (collection instanceof Set || collection instanceof Map) {
+    length = collection.size
+  } else {
+    throw new InternalError('plural expected a variable of type array/map/set, but received something else')
+  }
+
   return length === 1 ? '' : 's'
 }
 
+/**
+ * Change the First Letter Of A String To Uppercase
+ * @param {string} text
+ * @returns {string}
+ */
 export function ucFirst(text) {
   const firstLetter = text.slice(0, 1)
   return firstLetter.toUpperCase() + text.substring(1)

--- a/src/utils/treeUtils.js
+++ b/src/utils/treeUtils.js
@@ -1,6 +1,6 @@
 // Internal Dependencies
 import FileMissingError from '../errors/FileMissingError.js'
-import { info, logSpacer, logTitleItem } from './logger.js'
+import { fatal, info, logSpacer, logTitleItem } from './logger.js'
 
 /**
  * Validate Component Names
@@ -76,6 +76,26 @@ function folderTreeLog(component, last = false, grid = []) {
       folderTreeLog(snippet, lastChild, grid)
 
       lastChild && grid.pop()
+    }
+  }
+}
+
+/**
+ * Attach Child Components
+ * @param {Section[]|Component[]|Snippet[]} topElements
+ * @param {(Component|Snippet)[]} availableComponents
+ */
+export async function setComponentHierarchy(topElements, availableComponents) {
+  for (const topComponent of topElements) {
+    if (!topComponent.snippets?.length && topComponent.snippetNames?.length) {
+      for (const snippetName of topComponent.snippetNames) {
+        const snippet = availableComponents.find((component) => component.name === snippetName)
+        if (snippet !== undefined) {
+          topComponent.snippets.push(snippet)
+        } else {
+          fatal(`Unable to find component "${snippetName}" requested from a render tag in "${topComponent.name}".`)
+        }
+      }
     }
   }
 }

--- a/src/utils/treeUtils.js
+++ b/src/utils/treeUtils.js
@@ -1,6 +1,7 @@
 // Internal Dependencies
 import FileMissingError from '../errors/FileMissingError.js'
-import { fatal, info, logSpacer, logTitleItem } from './logger.js'
+import { fatal, info, logSpacer, logTitleItem, warn } from './logger.js'
+import Session from '../models/static/Session.js'
 
 /**
  * Validate Component Names
@@ -41,7 +42,16 @@ export async function setComponentHierarchy(topElements, availableComponents) {
         if (snippet !== undefined) {
           topComponent.snippets.push(snippet)
         } else {
-          fatal(`Unable to find component "${snippetName}" requested from a render tag in "${topComponent.name}".`)
+          const message = `Unable to find component "${snippetName}" requested from a render tag in "${topComponent.name}".`
+          if (Session.isCollection()) {
+            // When we are playing with a collection, an invalid component name should create a fatal error
+            fatal(message)
+          } else {
+            // When we are playing with a theme,
+            // an unknown component name could be a reference to a theme's internal snippets,
+            // so a warning is enough
+            warn(message)
+          }
         }
       }
     }

--- a/src/utils/treeUtils.js
+++ b/src/utils/treeUtils.js
@@ -51,6 +51,9 @@ export async function setComponentHierarchy(topElements, availableComponents) {
             // an unknown component name could be a reference to a theme's internal snippets,
             // so a warning is enough
             warn(message)
+            warn(
+              `If "${snippetName}" is a custom theme snippet, this is expected behaviour. If not, check the components CHANGELOG.md for renamed/removed components.`
+            )
           }
         }
       }

--- a/src/utils/treeUtils.js
+++ b/src/utils/treeUtils.js
@@ -28,7 +28,11 @@ export function getComponentHierarchyNames(components, componentNames) {
   return componentHierarchyNames
 }
 
-export function displayComponentTree(collection) {
+/**
+ * Displays A Collection's Component Tree
+ * @param {module:models/Collection} collection
+ */
+export function displayCollectionTree(collection) {
   logTitleItem('Components Tree')
 
   logSpacer()

--- a/src/utils/treeUtils.js
+++ b/src/utils/treeUtils.js
@@ -29,6 +29,26 @@ export function getComponentHierarchyNames(components, componentNames) {
 }
 
 /**
+ * Attach Child Components
+ * @param {Section[]|Component[]|Snippet[]} topElements
+ * @param {(Component|Snippet)[]} availableComponents
+ */
+export async function setComponentHierarchy(topElements, availableComponents) {
+  for (const topComponent of topElements) {
+    if (!topComponent.snippets?.length && topComponent.snippetNames?.length) {
+      for (const snippetName of topComponent.snippetNames) {
+        const snippet = availableComponents.find((component) => component.name === snippetName)
+        if (snippet !== undefined) {
+          topComponent.snippets.push(snippet)
+        } else {
+          fatal(`Unable to find component "${snippetName}" requested from a render tag in "${topComponent.name}".`)
+        }
+      }
+    }
+  }
+}
+
+/**
  * Displays A Collection's Component Tree
  * @param {module:models/Collection} collection
  */
@@ -47,6 +67,24 @@ export function displayCollectionTree(collection) {
   for (const [i, component] of sectionComponents.entries()) {
     const last = i === sectionComponents.length - 1
     folderTreeLog(component, last)
+  }
+}
+
+/**
+ * Displays A Theme's Component Tree
+ * @param {Theme} theme
+ */
+export function displayThemeTree(theme) {
+  logTitleItem('Theme Sections Tree')
+
+  logSpacer()
+  info(`${theme.name}/`)
+
+  // Top level is section components only
+
+  for (const [i, section] of theme.sections.entries()) {
+    const last = i === theme.sections.length - 1
+    folderTreeLog(section, last)
   }
 }
 
@@ -77,43 +115,5 @@ function folderTreeLog(component, last = false, grid = []) {
 
       lastChild && grid.pop()
     }
-  }
-}
-
-/**
- * Attach Child Components
- * @param {Section[]|Component[]|Snippet[]} topElements
- * @param {(Component|Snippet)[]} availableComponents
- */
-export async function setComponentHierarchy(topElements, availableComponents) {
-  for (const topComponent of topElements) {
-    if (!topComponent.snippets?.length && topComponent.snippetNames?.length) {
-      for (const snippetName of topComponent.snippetNames) {
-        const snippet = availableComponents.find((component) => component.name === snippetName)
-        if (snippet !== undefined) {
-          topComponent.snippets.push(snippet)
-        } else {
-          fatal(`Unable to find component "${snippetName}" requested from a render tag in "${topComponent.name}".`)
-        }
-      }
-    }
-  }
-}
-
-/**
- * Displays A Theme's Component Tree
- * @param {Theme} theme
- */
-export function displayThemeTree(theme) {
-  logTitleItem('Theme Sections Tree')
-
-  logSpacer()
-  info(`${theme.name}/`)
-
-  // Top level is section components only
-
-  for (const [i, section] of theme.sections.entries()) {
-    const last = i === theme.sections.length - 1
-    folderTreeLog(section, last)
   }
 }

--- a/src/utils/treeUtils.js
+++ b/src/utils/treeUtils.js
@@ -99,3 +99,21 @@ export async function setComponentHierarchy(topElements, availableComponents) {
     }
   }
 }
+
+/**
+ * Displays A Theme's Component Tree
+ * @param {Theme} theme
+ */
+export function displayThemeTree(theme) {
+  logTitleItem('Theme Sections Tree')
+
+  logSpacer()
+  info(`${theme.name}/`)
+
+  // Top level is section components only
+
+  for (const [i, section] of theme.sections.entries()) {
+    const last = i === theme.sections.length - 1
+    folderTreeLog(section, last)
+  }
+}

--- a/test/commands/theme/component/dev.test.js
+++ b/test/commands/theme/component/dev.test.js
@@ -83,7 +83,7 @@ describe('Dev Command File', async function () {
       await Dev.setSessionValues(argv, flags, metadata, tomlConfig)
 
       assert.strictEqual(Session.callerType, 'collection')
-      assert.deepStrictEqual(Session.components, null)
+      assert.deepStrictEqual(Session.componentNames, null)
       assert.strictEqual(Session.localesPath, Dev.flags[LOCALES_FLAG_NAME].default)
       assert.strictEqual(Session.watchMode, Dev.flags[WATCH_FLAG_NAME].default)
       assert.strictEqual(Session.setupFiles, Dev.flags[SETUP_FLAG_NAME].default)
@@ -119,7 +119,7 @@ describe('Dev Command File', async function () {
       await Dev.setSessionValues(argv, flags, metadata, tomlConfig)
 
       assert.strictEqual(Session.callerType, 'collection')
-      assert.deepStrictEqual(Session.components, null)
+      assert.deepStrictEqual(Session.componentNames, null)
       assert.strictEqual(Session.localesPath, Dev.flags[LOCALES_FLAG_NAME].default)
       assert.strictEqual(Session.watchMode, Dev.flags[WATCH_FLAG_NAME].default)
       assert.strictEqual(Session.setupFiles, false)
@@ -155,7 +155,7 @@ describe('Dev Command File', async function () {
       await Dev.setSessionValues(argv, flags, metadata, tomlConfig)
 
       assert.strictEqual(Session.callerType, 'collection')
-      assert.deepStrictEqual(Session.components, null)
+      assert.deepStrictEqual(Session.componentNames, null)
       assert.strictEqual(Session.localesPath, Dev.flags[LOCALES_FLAG_NAME].default)
       assert.strictEqual(Session.watchMode, Dev.flags[WATCH_FLAG_NAME].default)
       assert.strictEqual(Session.setupFiles, false)
@@ -191,7 +191,7 @@ describe('Dev Command File', async function () {
       await Dev.setSessionValues(argv, flags, metadata, tomlConfig)
 
       assert.strictEqual(Session.callerType, 'collection')
-      assert.deepStrictEqual(Session.components, null)
+      assert.deepStrictEqual(Session.componentNames, null)
       assert.strictEqual(Session.localesPath, Dev.flags[LOCALES_FLAG_NAME].default)
       assert.strictEqual(Session.watchMode, Dev.flags[WATCH_FLAG_NAME].default)
       assert.strictEqual(Session.setupFiles, false)
@@ -231,7 +231,7 @@ describe('Dev Command File', async function () {
       await Dev.setSessionValues(argv, flags, metadata, tomlConfig)
 
       assert.strictEqual(Session.callerType, 'collection')
-      assert.deepStrictEqual(Session.components, ['section-alpha', 'shopping-cart'])
+      assert.deepStrictEqual(Session.componentNames, ['section-alpha', 'shopping-cart'])
       assert.strictEqual(Session.localesPath, Dev.flags[LOCALES_FLAG_NAME].default)
       assert.strictEqual(Session.watchMode, false)
       assert.strictEqual(Session.setupFiles, true)


### PR DESCRIPTION
## [3.7.0] — 2024-06-07

### Added

- Required Theme Components Autodetect: We are now reading a theme's section files to scan for required components #403

### Changed

- install cmd: We now use the new required theme components autodetect feature instead of defaulting to all components #403
- Dependencies: Minor updates
- ImportMap: importmap.json can now handle array values. The values can include glob patterns or ignore patterns
  starting with "!"
- ImportMap: Filtering removed — Whatever globs are in the Import Map is what gets output

### Fixed

- install cmd: Import Map caused Errors when installing a single component with no Js Files
