### PR TITLE
Generate full importmap

### DIFF
--- a/src/processors/ImportMapProcessor.js
+++ b/src/processors/ImportMapProcessor.js
@@ -45,6 +45,7 @@ class ImportMapProcessor {
     const entries = Object.entries(imports)
     const modulePatterns = this.resolveModulePatterns(entries)
     const files = glob.sync(modulePatterns, {
+      ignore: "**.*.spec.js",
       cwd: collectionRootFolder,
       absolute: true
     })
@@ -89,15 +90,15 @@ class ImportMapProcessor {
     await init
     /** @type {Map<string, string>} */
     const map = new Map()
-    const promises = []
+    // const promises = []
     for (const [moduleSpecifier, modulePath] of importMapEntries) {
-      if (!jsFiles.has(path.resolve(modulePath))) {
-        continue
-      }
+      // if (!jsFiles.has(path.resolve(modulePath))) {
+      //   continue
+      // }
       map.set(moduleSpecifier, modulePath)
-      promises.push(this.processJsFile(modulePath, importMapEntries, map))
+      // promises.push(this.processJsFile(modulePath, importMapEntries, map))
     }
-    await Promise.all(promises)
+    // await Promise.all(promises)
     return map
   }
 

--- a/src/processors/ImportMapProcessor.js
+++ b/src/processors/ImportMapProcessor.js
@@ -27,6 +27,7 @@ class ImportMapProcessor {
     /** @type {{imports: Object<string, string>}} */
     const importMapJson = await getJsonFileContents(importMapFile)
     const importMapEntries = this.resolveImportMapEntries(importMapJson.imports, collectionRootFolder)
+    // TODO Filter importmap entries based on jsFiles passed in. Make sure jsFiles are being sourced from component.liquid files
     importMap.tags = this.generateImportMapTags(importMapEntries)
     importMap.entries = this.filterBuildEntries(importMapEntries, jsFilesSet)
     return importMap

--- a/src/processors/ImportMapProcessor.js
+++ b/src/processors/ImportMapProcessor.js
@@ -45,7 +45,7 @@ class ImportMapProcessor {
     const entries = Object.entries(imports)
     const modulePatterns = this.resolveModulePatterns(entries)
     const files = glob.sync(modulePatterns, {
-      ignore: "**.*.spec.js",
+      ignore: "**/*.spec.js",
       cwd: collectionRootFolder,
       absolute: true
     })
@@ -92,6 +92,7 @@ class ImportMapProcessor {
     const map = new Map()
     // const promises = []
     for (const [moduleSpecifier, modulePath] of importMapEntries) {
+      // TODO 
       // if (!jsFiles.has(path.resolve(modulePath))) {
       //   continue
       // }

--- a/src/processors/ImportMapProcessor.js
+++ b/src/processors/ImportMapProcessor.js
@@ -27,10 +27,8 @@ class ImportMapProcessor {
     /** @type {{imports: Object<string, string>}} */
     const importMapJson = await getJsonFileContents(importMapFile)
     const importMapEntries = this.resolveImportMapEntries(importMapJson.imports, collectionRootFolder)
-    const buildEntries = await this.resolveBuildEntries(jsFilesSet, importMapEntries)
-    const sortedBuildEntries = new Map([...buildEntries.entries()].sort())
-    importMap.tags = this.generateImportMapTags(sortedBuildEntries)
-    importMap.entries = this.filterBuildEntries(sortedBuildEntries, jsFilesSet)
+    importMap.tags = this.generateImportMapTags(importMapEntries)
+    importMap.entries = this.filterBuildEntries(importMapEntries, jsFilesSet)
     return importMap
   }
 
@@ -77,7 +75,8 @@ class ImportMapProcessor {
         map.set(this.getModuleSpecifier(file, specifierPattern), file)
       }
     }
-    return map
+
+    return new Map([...map.entries()].sort());
   }
 
   /**
@@ -115,28 +114,6 @@ class ImportMapProcessor {
    */
   static getModuleSpecifier(file, specifierPattern) {
     return specifierPattern.replace(/\*$/, path.parse(file).name)
-  }
-
-  /**
-   * Resolve build entries from component JS entry points
-   * @param {Set<string>} jsFiles
-   * @param {Map<string, string>} importMapEntries
-   */
-  static async resolveBuildEntries(jsFiles, importMapEntries) {
-    await init
-    /** @type {Map<string, string>} */
-    const map = new Map()
-    // const promises = []
-    for (const [moduleSpecifier, modulePath] of importMapEntries) {
-      // TODO 
-      // if (!jsFiles.has(path.resolve(modulePath))) {
-      //   continue
-      // }
-      map.set(moduleSpecifier, modulePath)
-      // promises.push(this.processJsFile(modulePath, importMapEntries, map))
-    }
-    // await Promise.all(promises)
-    return map
   }
 
   /**

--- a/src/processors/ImportMapProcessor.js
+++ b/src/processors/ImportMapProcessor.js
@@ -109,14 +109,6 @@ class ImportMapProcessor {
   }
 
   /**
-   * Resolve glob ignore patterns from import map entries
-   * @param {[string, string|Array<string>][]} entries
-   */
-  static resolveIgnorePatterns(entries) {
-    return entries.map(([, modulePattern]) => modulePattern).filter((modulePattern) => !isUrl(modulePattern))
-  }
-
-  /**
    * Get the module specifier for a given JS file
    * @param {string} file
    * @param {string} specifierPattern


### PR DESCRIPTION
Import maps were previously being built with the following approach:
1. Read importmap.json file for globs and get list of files
2. Filter the files by looking at each component JS entrypoint (a JS file with the same name as the component in it's assets folder) to see if any of the files are being used

This approach does not work if you want to just reference other files in the import map directly from the component liquid file like in https://github.com/archetype-themes/components/pull/936

This new approach:
1. importmap.json file can now have values that are arrays. The values can be include patterns or ignorepatterns (start with !)
2. No filtering is done -- whatever globs are in the importmap is what gets output 

New importmap.json file https://github.com/archetype-themes/components/pull/943