### PR TITLE
chore: Add oclif github actions

### DIFF
--- a/.github/workflows/onPushToMain.yml
+++ b/.github/workflows/onPushToMain.yml
@@ -1,0 +1,63 @@
+# test
+name: version, tag and github release
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+      - name: Generate GitHub App Token
+        id: generate-token
+        uses: tibdex/github-app-token@v1
+        with:
+          app_id: ${{ secrets.ARCHETYPE_GITHUB_APP_ID }}
+          private_key: ${{ secrets.ARCHETYPE_GITHUB_APP_KEY }}
+
+      - name: Check if version already exists
+        id: version-check
+        run: |
+          package_version=$(node -p "require('./package.json').version")
+          exists=$(gh api repos/${{ github.repository }}/releases/tags/v$package_version >/dev/null 2>&1 && echo "true" || echo "")
+
+          if [ -n "$exists" ];
+          then
+            echo "Version v$package_version already exists"
+            echo "::warning file=package.json,line=1::Version v$package_version already exists - no release will be created. If you want to create a new release, please update the version in package.json and push again."
+            echo "skipped=true" >> $GITHUB_OUTPUT
+          else
+            echo "Version v$package_version does not exist. Creating release..."
+            echo "skipped=false" >> $GITHUB_OUTPUT
+            echo "tag=v$package_version" >> $GITHUB_OUTPUT
+          fi
+        env:
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
+      - name: Setup git
+        if: ${{ steps.version-check.outputs.skipped == 'false' }}
+        run: |
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+      - name: Generate oclif README
+        if: ${{ steps.version-check.outputs.skipped == 'false' }}
+        id: oclif-readme
+        run: |
+          <%- install %>
+          <%- exec %> oclif readme
+          if [ -n "$(git status --porcelain)" ]; then
+            git add .
+            git commit -am "chore: update README.md"
+            git push -u origin ${{ github.ref_name }}
+          fi
+      - name: Create Github Release
+        uses: ncipollo/release-action@2c591bcc8ecdcd2db72b97d6147f871fcd833ba5
+        if: ${{ steps.version-check.outputs.skipped == 'false' }}
+        with:
+          name: ${{ steps.version-check.outputs.tag }}
+          tag: ${{ steps.version-check.outputs.tag }}
+          commit: ${{ github.ref_name }}
+          token: ${{ steps.generate-token.outputs.token }}
+          skipIfReleaseExists: true

--- a/.github/workflows/onRelease.yml
+++ b/.github/workflows/onRelease.yml
@@ -1,0 +1,21 @@
+name: publish
+
+on:
+  release:
+    types: [released]
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: latest
+      - run: <%- install %>
+      - run: <%- run %> build
+      - run: <%- run %> prepack
+      - uses: JS-DevTools/npm-publish@19c28f1ef146469e409470805ea4279d47c3d35c
+        with:
+          token: ${{ secrets.NPM_TOKEN }}
+      - run: <%- run %> postpack

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,24 @@
+name: tests
+on:
+  push:
+    branches-ignore: [main]
+  workflow_dispatch:
+
+jobs:
+  unit-tests:
+    strategy:
+      matrix:
+        # os: ['ubuntu-latest', 'windows-latest']
+        os: ['ubuntu-latest']
+        node_version: [lts/-1, lts/*, latest]
+      fail-fast: false
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node_version }}
+          cache: npm
+      - run: npm install
+      - run: npm run build
+      - run: npm run test


### PR DESCRIPTION
- Adds action to create Github relase when package.json version is bumped
- Adds action to publish to NPM when Github release is created
- Adds action to run tests on push
- Not adding Windows tests for now because they have a permission that is failing when we try to clean up test fixture files